### PR TITLE
Posibility to configure response type

### DIFF
--- a/src/DI/OAuth2ServerExtension.php
+++ b/src/DI/OAuth2ServerExtension.php
@@ -58,6 +58,7 @@ class OAuth2ServerExtension extends CompilerExtension
 				self::GRANT_PASSWORD => Expect::bool(false),
 				self::GRANT_REFRESH_TOKEN => Expect::bool(false),
 			]),
+			'responseType' => Expect::type(Statement::class),
 		]);
 	}
 
@@ -75,6 +76,7 @@ class OAuth2ServerExtension extends CompilerExtension
 			->setFactory(AuthorizationServer::class, [
 				'privateKey' => $privateKey,
 				'encryptionKey' => $config->encryptionKey,
+				'responseType' => $config->responseType,
 			]);
 
 		$builder->addDefinition($this->prefix('resourceServer'))


### PR DESCRIPTION
 Authorization server in constructor accepts responseType parameter. If needed, it is possible to pass own instance of response object to modify token endpoint response. Motivation to do this is for example, add identity token to token response.